### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 pos/
+.DS_Store


### PR DESCRIPTION
Added .DS_Store to .gitignore to prevent macOS system files from being tracked in the repository.